### PR TITLE
Fix: Improve Prefect server startup and Postgres image pull logic

### DIFF
--- a/workflow/scripts/start_postgres.sh
+++ b/workflow/scripts/start_postgres.sh
@@ -98,9 +98,9 @@ then
         if [[ ! -e postgres_latest.sif ]]
         then
             echo "Downloading the latest postgres docker container"
-            singularity pull docker://postgres
-            container_image=$(pwd)/postgres_latest.sif
+            singularity pull docker://postgres            
         fi
+        container_image=$(pwd)/postgres_latest.sif
     fi 
     # set the singularity arguments 
     singargs="--cleanenv --bind $POSTGRES_SCRATCH:/var"


### PR DESCRIPTION
- Use prefect server start for the initial launch to avoid Alembic migration errors when the database is empty.
- Optimize logic for pulling and using the Postgres Singularity image; ensure the image is downloaded and the vars are set only if not already present.

Details:
**1. Initial Execution Issue with Uvicorn**
If you use uvicorn directly for the first startup, Prefect will not run the necessary Alembic migrations automatically. This results in errors because the database schema hasn’t been initialised yet. Using `prefect server start` for the initial launch ensures that all required migrations are applied, and the server can start successfully.

**2. Issue When Singularity Image Is Already Downloaded**

Previously, the script didn’t properly check if the Postgres Singularity image was already present, which could lead to an unset vars issue. The updated logic now only pulls the image if it’s missing, preventing the unset issue.